### PR TITLE
fix: Fixed "Show side of card: Back" behavior

### DIFF
--- a/src/script/ui/MenuBar.tsx
+++ b/src/script/ui/MenuBar.tsx
@@ -9,6 +9,7 @@ import { useContext } from "react"
 import { AppState } from "../App"
 import Latex from "react-latex-next"
 import { makeReviewOrderProvider } from "../ReviewOrder"
+import ShowSideProvider from "../ShowSideProvider"
 
 
 
@@ -66,6 +67,7 @@ function MenuBar() {
               appState.setVisibleCardIndex(peekValue);
             }
             appState.setReviewOrderProviderNextValue(reviewOrderProvider.next());
+            appState.setVisibleSide(ShowSideProvider.get(appState.showSideProviderName)());
           }} />
         }
         {(appMode === AppMode.EDITING_DECK || appMode === AppMode.REVIEWING_DECK) &&

--- a/src/script/ui/ReviewCardPopover.tsx
+++ b/src/script/ui/ReviewCardPopover.tsx
@@ -54,7 +54,10 @@ function ReviewCardPopover() {
                     (
                       <Button className="d-flex align-items-center flashcard-button" onClick={() => {
                         setReviewingCardState(ReviewingCardState.VIEWING_QUESTION_SIDE);
-                        appState.setVisibleSide(ShowSideProvider.get(appState.showSideProviderName)());
+
+                        const side = ShowSideProvider.get(appState.showSideProviderName)();
+                        console.log(side);
+                        appState.setVisibleSide(side);
 
                         const next = appState.reviewOrderProvider.next()
                         appState.setReviewOrderProviderNextValue(next);


### PR DESCRIPTION
Previously, the front of the card would always be shown first regardless of whether the user selected the "Show side of card: Back" or "Show side of card: Front" options in the Deck Review Settings menu. This has been fixed.