### PR TITLE
fix: Fixed "Show side of card: Random" behavior

### DIFF
--- a/src/script/ReviewOrder.ts
+++ b/src/script/ReviewOrder.ts
@@ -86,7 +86,6 @@ export const makeRandomOrderProvider = (numCards: number) => {
     for (let i = 0; i < numCards; i++) {
         let index;
         do { index = Math.floor(Math.random() * numCards); } while (used[index]);
-        console.log(`i=${i}; index=${index}; numbers=${numbers.toString()}`)
         
         used[index] = true;
         numbers[i] = index;

--- a/src/script/ShowSideProvider.ts
+++ b/src/script/ShowSideProvider.ts
@@ -2,7 +2,7 @@ import { Side } from "./card/side"
 
 const ShowSideProviderFront = Object.freeze(() => Side.FRONT)
 const ShowSideProviderBack = Object.freeze(() => Side.BACK)
-const ShowSideProviderRandom = Object.freeze(() => (Math.random() * 10) > 0.5 ? Side.FRONT : Side.BACK)
+const ShowSideProviderRandom = Object.freeze(() => (Math.random() * 10) > 5 ? Side.FRONT : Side.BACK)
 
 type ShowSideProviderName = "FRONT" | "BACK" | "RANDOM"
 

--- a/src/script/ui/ReviewCardPopover.tsx
+++ b/src/script/ui/ReviewCardPopover.tsx
@@ -54,10 +54,7 @@ function ReviewCardPopover() {
                     (
                       <Button className="d-flex align-items-center flashcard-button" onClick={() => {
                         setReviewingCardState(ReviewingCardState.VIEWING_QUESTION_SIDE);
-
-                        const side = ShowSideProvider.get(appState.showSideProviderName)();
-                        console.log(side);
-                        appState.setVisibleSide(side);
+                        appState.setVisibleSide(ShowSideProvider.get(appState.showSideProviderName)());
 
                         const next = appState.reviewOrderProvider.next()
                         appState.setReviewOrderProviderNextValue(next);


### PR DESCRIPTION
Previously, the back of the card would only be shown to the user first a very low percentage of the time, rather than 50% as intended. This has been fixed.

Removed several unnecessary console.log statements